### PR TITLE
Adds test case for lambdas that return lambdas using concise body syntax

### DIFF
--- a/AdobeCF.cfm
+++ b/AdobeCF.cfm
@@ -87,6 +87,16 @@
 	
 	writeOutput( '<h1>12</h1>' )
     myarray = [ ()=>12 ]
-    writeOutput( myarray[ 1 ]() )
+	writeOutput( myarray[ 1 ]() )
+	
+	writeOutput( '<h1>Hi Adobe</h1>' )
+	// Invalid CFML construct found on line 2 at column 26. on line 2
+	// https://tracker.adobe.com/#/view/CF-4205268
+	//say = (message)=>(to)=>()=>"#message# #to#";
+	// workaround:
+	say = (message)=>{ return (to)=>{return ()=>"Not saying: #message# #to#"}};
+	sayHi = say("Hi");
+	sayHiToAdobe = sayHi("Adobe");
+	writeDump( sayHiToAdobe() );	
 	
 </cfscript>

--- a/JavaScript.html
+++ b/JavaScript.html
@@ -69,5 +69,11 @@
 	document.write( '<h1>12</h1>' )
 	myarray = [ ()=>12 ]
 	document.write( myarray[ 0 ]() )
+
+	document.write( '<h1>Hi Adobe</h1>' )
+	say = (message)=>(to)=>()=>`${message} ${to}`
+	sayHi = say("Hi");
+	sayHiToAdobe = sayHi("Adobe");
+	document.write( sayHiToAdobe() );
 	
 </script>

--- a/Lucee.cfm
+++ b/Lucee.cfm
@@ -84,4 +84,11 @@
 	// The function [1] does not exist in the Object, only the following functions are available: [append,avg,clear,contains,containsNoCase,delete...
 	// https://luceeserver.atlassian.net/browse/LDEV-2489?
 	// writeOutput( myarray[ 1 ]() )
+
+	writeOutput( '<h1>Hi Adobe</h1>' )
+	say = (message)=>(to)=>()=>"#message# #to#";
+	sayHi = say("Hi");
+	sayHiToAdobe = sayHi("Adobe");
+	writeDump( sayHiToAdobe() );
+	
 </cfscript>


### PR DESCRIPTION
I commented out the offending code in the AdobeCF.cfm file because it causes a compile time error.  If you'd rather that fail, I'll update and re-submit.